### PR TITLE
fix: redirect old /docs/* URLs + PR review fixes

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from 'react';
-import { useRouter } from 'next/router';
 
 export default function NotFound() {
-  const router = useRouter();
 
   useEffect(() => {
     const path = window.location.pathname;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function NotFound() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const path = window.location.pathname;
+    // Redirect old Hugo /docs/* URLs to new root paths
+    if (path.startsWith('/docs/')) {
+      const newPath = path.replace(/^\/docs/, '');
+      window.location.replace(newPath || '/');
+    }
+  }, []);
+
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>404 — Page Not Found</h1>
+      <p>
+        <a href="/">Go to homepage</a>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Fixes

- Redirect old Hugo `/docs/*` URLs to new root paths (e.g. `/docs/getting-started/` → `/getting-started/`)
- Remove `next-env.d.ts` from `.gitignore` (P2 review issue)
- Add `.claude/` to `.gitignore` and remove from git tracking
- Fix broken Arabic first-login link in `_locales/ar/deployment/cloud-providers/linode.mdx` (P2 review issue)
- Deduplicate `.dockerignore`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects legacy Hugo `/docs/*` URLs to the new root paths via the 404 page so old links keep working. Also fixes a broken Arabic link and cleans up ignore files.

- **Bug Fixes**
  - Redirect `/docs/*` → root paths (e.g., `/docs/getting-started/` → `/getting-started/`) via `pages/404.tsx`.
  - Fix broken Arabic first-login link in `_locales/ar/deployment/cloud-providers/linode.mdx`.

- **Refactors**
  - Stop ignoring `next-env.d.ts`.
  - Add `.claude/` to `.gitignore` and remove from tracking.
  - Deduplicate `.dockerignore`.

<sup>Written for commit 10c79d84b73a47c7f228516db237db77cc19bb92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

