### PR TITLE
fix: handle /docs redirect without trailing slash

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,10 +4,10 @@ export default function NotFound() {
 
   useEffect(() => {
     const path = window.location.pathname;
-    // Redirect old Hugo /docs/* URLs to new root paths
-    if (path.startsWith('/docs/')) {
-      const newPath = path.replace(/^\/docs/, '');
-      window.location.replace(newPath || '/');
+    // Redirect old Hugo /docs and /docs/* URLs to new root paths
+    if (path === '/docs' || path.startsWith('/docs/')) {
+      const newPath = path.replace(/^\/docs/, '') || '/';
+      window.location.replace(newPath);
     }
   }, []);
 


### PR DESCRIPTION
Fix 404 redirect to handle both /docs and /docs/* paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 404 redirect to correctly reroute legacy docs URLs with or without a trailing slash. Requests to /docs now go to /, and /docs/* now map to /* (e.g., /docs/foo -> /foo), preventing 404s.

<sup>Written for commit d4d961406e6f31383120f0b1ebc1fef853b0034b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

