### PR TITLE
feat: add Community pages (Contact, Support, Sponsor) with FeatureCard layout

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,13 +1,2 @@
-# These are supported funding model platforms
-
-github: [colinwilson]
-patreon: # Replace with a single Patreon username
-open_collective: lotuslabs
-ko_fi: colinwilson
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+github: [therealtimex]
+custom: ['https://rtsurvey.com/sponsor']

--- a/components/FeatureCard.tsx
+++ b/components/FeatureCard.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from 'react';
+import { useRouter } from 'next/router';
+
+interface FeatureCardProps {
+  title: string;
+  href: string;
+  icon: ReactNode;
+  iconColor?: string;
+  children: ReactNode;
+}
+
+export default function FeatureCard({ title, href, icon, iconColor = '#226cff', children }: FeatureCardProps) {
+  const { basePath } = useRouter();
+  const isExternal = href.startsWith('http') || href.startsWith('mailto:');
+
+  return (
+    <a
+      href={isExternal ? href : `${basePath}${href}`}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noopener noreferrer' : undefined}
+      style={{
+        display: 'block',
+        padding: '1.25rem 1.5rem',
+        borderRadius: '1rem',
+        border: '1px solid #e5e7eb',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
+        background: '#fff',
+        textDecoration: 'none',
+        color: 'inherit',
+        transition: 'box-shadow 0.15s, border-color 0.15s',
+      }}
+      onMouseEnter={e => {
+        (e.currentTarget as HTMLAnchorElement).style.boxShadow = '0 4px 16px rgba(0,0,0,0.1)';
+        (e.currentTarget as HTMLAnchorElement).style.borderColor = '#d1d5db';
+      }}
+      onMouseLeave={e => {
+        (e.currentTarget as HTMLAnchorElement).style.boxShadow = '0 2px 8px rgba(0,0,0,0.04)';
+        (e.currentTarget as HTMLAnchorElement).style.borderColor = '#e5e7eb';
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.5rem' }}>
+        <span style={{ color: iconColor, display: 'flex', alignItems: 'center' }}>{icon}</span>
+        <span style={{ fontWeight: 600, fontSize: '0.95rem' }}>{title}</span>
+      </div>
+      <div style={{ fontSize: '0.875rem', color: '#6b7280', lineHeight: 1.5 }}>{children}</div>
+    </a>
+  );
+}

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -10,7 +10,11 @@
   "deployment": "Deployment",
   "survey-design": "Survey Design",
   "platform-interfaces": "Platform Interfaces",
-  "contact": "Contact Us",
+  "-- community --": {
+    "type": "separator",
+    "title": "Community"
+  },
   "support": "Support",
+  "contact": "Contact Us",
   "sponsor": "Sponsor"
 }

--- a/pages/contact.mdx
+++ b/pages/contact.mdx
@@ -1,8 +1,35 @@
 ---
 title: "Contact Us"
-description: "Get in touch with the rtSurvey team."
+description: "Get in touch with the rtSurvey team for support, enterprise inquiries, and partnerships."
 ---
 
 # Contact Us
 
-For support and inquiries, please reach out to us.
+## General & Support
+
+Email us at **[support@rta.vn](mailto:support@rta.vn)** for questions, deployment help, or anything else.
+
+For technical bugs and feature requests, please use [GitHub Issues](https://github.com/therealtimex/rtsurvey/issues) so the community can benefit from the discussion.
+
+---
+
+## Enterprise & Partnerships
+
+Need a custom deployment, SLA support, or integration assistance? Visit **[rtsurvey.com](https://rtsurvey.com)** or email us directly.
+
+---
+
+## Security
+
+Please do **not** open public GitHub Issues for security vulnerabilities. Contact us privately at [support@rta.vn](mailto:support@rta.vn) with the subject line `[Security]`.
+
+---
+
+## Find Us
+
+| Channel | Link |
+|---------|------|
+| Email | [support@rta.vn](mailto:support@rta.vn) |
+| Website | [rtsurvey.com](https://rtsurvey.com) |
+| GitHub | [github.com/therealtimex/rtsurvey](https://github.com/therealtimex/rtsurvey) |
+| X (Twitter) | [@RtSurvey](https://twitter.com/RtSurvey) |

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -3,13 +3,66 @@ title: "rtSurvey Documentation"
 description: "Official documentation for rtSurvey — a self-hosted mobile data collection and survey platform."
 ---
 
+import FeatureCard from '../components/FeatureCard';
+
 # rtSurvey Documentation
 
 Welcome to the official documentation for **rtSurvey** — a self-hosted platform for designing forms, collecting data in the field, and analyzing results in real time.
 
-## Quick Links
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '1rem', marginTop: '2rem', marginBottom: '2rem' }}>
 
-- [Getting Started](/getting-started/overview)
-- [Deploy Your Server](/deployment/quick-start)
-- [Survey Design](/survey-design/key-concepts)
-- [Platform Interfaces](/platform-interfaces)
+<FeatureCard
+  title="Getting Started"
+  href="/getting-started/overview"
+  iconColor="#0da37f"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>}
+>
+  New to rtSurvey? Start here for a platform overview.
+</FeatureCard>
+
+<FeatureCard
+  title="Deployment"
+  href="/deployment/quick-start"
+  iconColor="#226cff"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>}
+>
+  Deploy on Linode, DigitalOcean, or any Linux server.
+</FeatureCard>
+
+<FeatureCard
+  title="Survey Design"
+  href="/survey-design/key-concepts"
+  iconColor="#f59e0b"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>}
+>
+  Build forms with questions, logic, media, and repeats.
+</FeatureCard>
+
+<FeatureCard
+  title="Platform Interfaces"
+  href="/platform-interfaces/rtsurvey-cloud/overview"
+  iconColor="#8250df"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>}
+>
+  Explore the web app, mobile app, and web form.
+</FeatureCard>
+
+<FeatureCard
+  title="Support"
+  href="/support"
+  iconColor="#ea4335"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 0 2 2z"/></svg>}
+>
+  GitHub Issues, community discussions, and email support.
+</FeatureCard>
+
+<FeatureCard
+  title="GitHub"
+  href="https://github.com/therealtimex/rtsurvey"
+  iconColor="#24292e"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>}
+>
+  View source, open issues, and contribute.
+</FeatureCard>
+
+</div>

--- a/pages/sponsor.mdx
+++ b/pages/sponsor.mdx
@@ -1,8 +1,69 @@
 ---
-title: "Sponsor"
-description: "Support rtSurvey development."
+title: "Sponsor rtSurvey"
+description: "Support the development of rtSurvey — a free, self-hosted mobile data collection platform."
 ---
+
+import FeatureCard from '../components/FeatureCard';
 
 # Sponsor rtSurvey
 
-rtSurvey is an open-source project. Consider supporting its development.
+rtSurvey is a free, open-source, self-hosted platform for field data collection. There are no SaaS fees, no vendor lock-in, and no data leaving your servers.
+
+Keeping it that way requires ongoing development, infrastructure, and documentation. If rtSurvey saves your organization time or money, consider supporting its development.
+
+---
+
+## Ways to Sponsor
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '1rem', marginTop: '1.5rem', marginBottom: '2rem' }}>
+
+<FeatureCard
+  title="GitHub Sponsors"
+  href="https://github.com/sponsors/therealtimex"
+  iconColor="#ea4aaa"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.593c-.5-.156-11-6.4-11-12.1C1 5.23 3.186 3 6 3c1.858 0 3.504.963 4.5 2.42C11.496 3.963 13.142 3 15 3c2.814 0 5 2.23 5 6.493 0 5.7-10.5 11.944-11 12.1l-1 .407-1-.407z"/></svg>}
+>
+  Monthly recurring support via GitHub. Any amount helps — starts at $5/month.
+</FeatureCard>
+
+<FeatureCard
+  title="Enterprise Sponsorship"
+  href="mailto:support@rta.vn?subject=[Sponsorship]"
+  iconColor="#226cff"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>}
+>
+  Custom tiers for organizations. Includes logo placement, priority support, and more.
+</FeatureCard>
+
+</div>
+
+---
+
+## Enterprise Tiers
+
+For organizations that deploy rtSurvey at scale:
+
+| Tier | Monthly | Benefits |
+|------|---------|----------|
+| **Bronze** 🥉 | $500 | Logo in README, thank-you in release notes |
+| **Silver** 🥈 | $2,000 | All Bronze + priority issue response, logo in docs footer |
+| **Gold** 🥇 | $5,000 | All Silver + co-marketing, early access to new features |
+| **Platinum** 💎 | $15,000 | All Gold + dedicated support hours, custom integration assistance |
+| **Custom** 🎯 | Flexible | Tailored package — contact us to discuss |
+
+Email **[support@rta.vn](mailto:support@rta.vn?subject=[Sponsorship])** to get started.
+
+---
+
+## What Your Sponsorship Funds
+
+- Core platform development and bug fixes
+- Cloud marketplace images (Linode, DigitalOcean)
+- Documentation and translations (35+ languages)
+- Infrastructure and CI/CD costs
+
+---
+
+## Current Sponsors
+
+*Be the first sponsor — [get in touch](mailto:support@rta.vn?subject=[Sponsorship]).*

--- a/pages/support.mdx
+++ b/pages/support.mdx
@@ -1,8 +1,79 @@
 ---
 title: "Support"
-description: "Get help with rtSurvey."
+description: "Get help with rtSurvey — documentation, GitHub Issues, and community resources."
 ---
+
+import FeatureCard from '../components/FeatureCard';
 
 # Support
 
-Find answers, documentation, and community help for rtSurvey.
+rtSurvey is an open-source, self-hosted platform. Support is provided through GitHub and community channels.
+
+## Get Help
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '1rem', marginTop: '1.5rem', marginBottom: '2rem' }}>
+
+<FeatureCard
+  title="GitHub Issues"
+  href="https://github.com/therealtimex/rtsurvey/issues"
+  iconColor="#24292e"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>}
+>
+  Report bugs, request features, or browse known issues.
+</FeatureCard>
+
+<FeatureCard
+  title="GitHub Discussions"
+  href="https://github.com/therealtimex/rtsurvey/discussions"
+  iconColor="#8250df"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>}
+>
+  Ask questions and get help from the community.
+</FeatureCard>
+
+<FeatureCard
+  title="Documentation"
+  href="/"
+  iconColor="#0da37f"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>}
+>
+  Browse the full rtSurvey documentation.
+</FeatureCard>
+
+<FeatureCard
+  title="Email Support"
+  href="mailto:support@rta.vn"
+  iconColor="#ea4335"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>}
+>
+  Contact us directly at support@rta.vn.
+</FeatureCard>
+
+<FeatureCard
+  title="rtSurvey Website"
+  href="https://rtsurvey.com"
+  iconColor="#226cff"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>}
+>
+  Product information, demos, and enterprise inquiries.
+</FeatureCard>
+
+<FeatureCard
+  title="X (Twitter)"
+  href="https://twitter.com/RtSurvey"
+  iconColor="#000"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>}
+>
+  Follow @RtSurvey for updates and announcements.
+</FeatureCard>
+
+</div>
+
+## Before Opening an Issue
+
+Please search [existing issues](https://github.com/therealtimex/rtsurvey/issues) before creating a new one. Include:
+
+- rtSurvey version
+- Deployment method (Linode StackScript, DigitalOcean, manual Docker)
+- Steps to reproduce
+- Relevant logs (`docker compose logs`)

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -3,13 +3,26 @@ import { DocsThemeConfig } from 'nextra-theme-docs';
 
 const config: DocsThemeConfig = {
   project: {
-    link: 'https://github.com/rtSurvey',
+    link: 'https://github.com/therealtimex/rtsurvey',
   },
-  docsRepositoryBase: 'https://github.com/rtSurvey/docs',
+  chat: {
+    link: 'https://twitter.com/RtSurvey',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+      </svg>
+    ),
+  },
+  docsRepositoryBase: 'https://github.com/therealtimex/rtsurvey/tree/main/docs',
   footer: {
     text: (
       <span>
-        MIT {new Date().getFullYear()} © rtSurvey
+        MIT {new Date().getFullYear()} ©{' '}
+        <a href="https://rtsurvey.com" target="_blank" rel="noopener noreferrer">
+          rtSurvey
+        </a>
+        {' · '}
+        <a href="mailto:support@rta.vn">support@rta.vn</a>
       </span>
     )
   },


### PR DESCRIPTION
## Summary

- New `FeatureCard` component for card-based navigation grids (no new dependencies — inline SVG icons)
- Home page upgraded from plain bullet list to 6-card grid
- Full Contact, Support, and Sponsor pages implemented
- GitHub Sponsors + enterprise email tiers on Sponsor page
- Community separator added to sidebar nav
- Fixed stale `FUNDING.yml` (was colinwilson template)

## Pages added / updated

| Page | Description |
|------|-------------|
| `/` | 6-card grid: Getting Started, Deployment, Survey Design, Platforms, Support, GitHub |
| `/support` | Icon cards for GitHub Issues, Discussions, Docs, Email, Website, X/Twitter |
| `/contact` | Email, security reporting section, links table |
| `/sponsor` | GitHub Sponsors card + enterprise tier table (Bronze $500 → Platinum $15k) |

## Test plan

- [ ] Open http://localhost/ — verify 6 cards render correctly
- [ ] Open http://localhost/support/ — verify icon grid and links
- [ ] Open http://localhost/contact/ — verify email links and table
- [ ] Open http://localhost/sponsor/ — verify both cards and tier table
- [ ] Check "Community" separator appears in sidebar above Support/Contact/Sponsor
- [ ] Check X/Twitter icon appears in header (theme.config)
- [ ] Check footer shows rtsurvey.com and support@rta.vn

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Community pages (Contact, Support, Sponsor) and a reusable `FeatureCard` grid, upgrading the home page to a 6-card layout for faster navigation. Also updates the sidebar and fixes links and funding configuration.

- **New Features**
  - Reusable `FeatureCard` for card-based navigation (inline SVGs); home page now a 6-card grid.
  - New `/support` with cards for GitHub Issues, Discussions, Docs, Email, Website, and X/Twitter.
  - New `/contact` with support email, security reporting, and a quick links table.
  - New `/sponsor` with GitHub Sponsors and enterprise tiers (Bronze $500 → Platinum $15k).
  - Sidebar adds a “Community” separator grouping Support, Contact, and Sponsor.

- **Bug Fixes**
  - Updated `.github/FUNDING.yml` to `therealtimex` and added custom sponsor URL.
  - Fixed project/docs links in `theme.config.tsx`, added X/Twitter header icon, and updated footer with `rtsurvey.com` and `support@rta.vn`.

<sup>Written for commit 94e18368f080b8f51e81a1ebf07a9d137eb478c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

