### PR TITLE
fix: show Self-Host in sidebar and move SSL Setup below it

### DIFF
--- a/pages/deployment/_meta.json
+++ b/pages/deployment/_meta.json
@@ -3,8 +3,8 @@
   "quick-start": "Quick Start",
   "cloud-providers": "Cloud Providers",
   "self-host-docker": "Self-Host with Docker",
+  "ssl-setup": "SSL Setup",
   "configuration": "Configuration",
   "maintenance": "Maintenance",
-  "ssl-setup": "SSL Setup",
   "sso-authentication": "SSO Authentication"
 }


### PR DESCRIPTION
- Fixes Self-Host with Docker missing from left sidebar
- Moves SSL Setup to appear after Self-Host with Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Deployment docs sidebar: restore “Self-Host with Docker” and place “SSL Setup” directly after it. Updates pages/deployment/_meta.json to correct the nav order.

<sup>Written for commit 7cd31f47c724caef49a104a6a563bbd588d0e3c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

