### PR TITLE
fix: clean rebuild — bust stale CI cache causing missing sidebar item

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: .next/cache
           key: nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('pages/**') }}
-          restore-keys: nextjs-
+          restore-keys: nextjs-${{ hashFiles('**/yarn.lock') }}-
       - name: Build English
         run: NODE_OPTIONS='--max-old-space-size=6144' yarn build
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem
Self-Host with Docker page was missing from the sidebar on all other pages because the CI was restoring a stale Next.js cache via `restore-keys: nextjs-` fallback. The old cache had the page map without `self-host-docker`, so the shared layout chunks were served from cache even after the new page was added.

## Fix
- Deleted all stale `nextjs-*` caches from GitHub Actions
- Tightened `restore-keys` to `nextjs-{yarn.lock-hash}-` so only the webpack/framework cache is reused, not stale page maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing “Self-Host with Docker” sidebar item by preventing CI from restoring a stale Next.js cache. The workflow now scopes cache `restore-keys` to the `yarn.lock` hash so page map changes trigger a fresh build.

<sup>Written for commit 9a219a203f9e377ef85d388663fd6c336b39a34e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

