### PR TITLE
feat(docs): add AWS EC2 deployment guide

### DIFF
--- a/pages/deployment/cloud-providers/_meta.json
+++ b/pages/deployment/cloud-providers/_meta.json
@@ -1,4 +1,7 @@
 {
+  "index": { "display": "hidden" },
   "digitalocean": "DigitalOcean",
-  "linode": "Linode (Akamai)"
+  "linode": "Linode (Akamai)",
+  "gcp-compute-engine": "GCP Compute Engine",
+  "aws-ec2": "AWS EC2"
 }

--- a/pages/deployment/cloud-providers/aws-ec2.mdx
+++ b/pages/deployment/cloud-providers/aws-ec2.mdx
@@ -1,0 +1,128 @@
+---
+title: "AWS EC2"
+description: "Deploy rtCloud on an AWS EC2 instance using an automated user-data script. No configuration needed — just launch the instance and follow the post-deployment steps."
+---
+
+## Step 1 — Launch an EC2 instance
+
+1. Go to **[EC2 Console](https://console.aws.amazon.com/ec2)** → **Instances** → **Launch instances**
+2. Fill in the form:
+
+| Field | Recommended value |
+|-------|------------------|
+| **Name** | `rtsurvey-prod` |
+| **AMI** | Ubuntu Server 22.04 LTS (HVM) |
+| **Instance type** | `t3.medium` (2 vCPU / 4 GB RAM) |
+| **Key pair** | Select or create a key pair for SSH access |
+| **Security group** | Create new — see [Security group rules](#security-group-rules) below |
+
+3. Expand **Advanced details** → scroll to **User data**
+4. Paste the full contents of `aws-ec2.sh` into the **User data** field
+5. Click **Launch instance**
+
+> **No configuration needed.** The script uses safe defaults and starts in HTTP mode. You configure the domain and SSL from the app UI after the server is running — the same flow as Linode.
+
+**Download script:** [aws-ec2.sh](/scripts/aws-ec2.sh)
+
+### Recommended instance types
+
+| Instance type | RAM | ~$/month | Notes |
+|---------------|-----|----------|-------|
+| `t3.medium` | 4 GB | ~$30 | Minimum for Keycloak |
+| `t3.large` | 8 GB | ~$60 | Recommended for production |
+
+---
+
+## Step 2 — Configure security group rules
+
+Create a new security group with these inbound rules:
+
+| Type | Protocol | Port | Source | Notes |
+|------|----------|------|--------|-------|
+| SSH | TCP | 22 | Your IP | Admin access |
+| HTTP | TCP | 80 | 0.0.0.0/0 | Nginx + ACME challenge |
+| HTTPS | TCP | 443 | 0.0.0.0/0 | Nginx after SSL setup |
+| Custom TCP | TCP | 3838 | 0.0.0.0/0 | Shiny Server (R analytics) |
+
+> **Outbound:** Allow all (required for Docker image pulls and Let's Encrypt).
+
+---
+
+## Step 3 — Wait for setup to complete
+
+The script runs automatically on first boot. It installs Docker, pulls the rtCloud image, initialises the database, and starts all services. This takes **5–10 minutes**.
+
+**No console access needed.** Open your browser and go to `http://<instance-public-ip>`. You will see a loading page while the app finishes starting up. It refreshes automatically every 5 seconds and loads the app once ready.
+
+> The instance public IP is shown in the **EC2 → Instances** list. If you assigned an Elastic IP, use that instead.
+
+To watch the log directly:
+
+```bash
+ssh ubuntu@<instance-public-ip>
+sudo tail -f /var/log/rtcloud-setup.log
+```
+
+---
+
+## Step 4 — Set up SSL
+
+Once the app is running, follow the **[Set Up SSL guide →](../ssl-setup)** to configure HTTPS. The free **rtsurvey.com subdomain** is the fastest option — no DNS setup needed.
+
+---
+
+## Step 5 — Change the default password
+
+All passwords default to `admin`. Change them immediately after your first login:
+
+- **App admin password** — account settings inside the app
+- **Keycloak admin** — accessible at `https://your-domain.com/auth/admin` (login: `admin` / `admin`)
+
+---
+
+## Security group rules (reference)
+
+### Inbound
+
+| Type | Protocol | Port | Source | Notes |
+|------|----------|------|--------|-------|
+| SSH | TCP | 22 | Your IP | SSH access |
+| HTTP | TCP | 80 | 0.0.0.0/0 | Nginx HTTP + ACME challenge |
+| HTTPS | TCP | 443 | 0.0.0.0/0 | Nginx HTTPS after SSL setup |
+| Custom TCP | TCP | 3838 | 0.0.0.0/0 | Shiny Server (R analytics) |
+
+### Outbound
+
+| Type | Protocol | Port | Destination | Notes |
+|------|----------|------|-------------|-------|
+| All traffic | All | All | 0.0.0.0/0 | Docker pulls, certbot, etc. |
+
+### Ports NOT needed externally
+
+| Port | Service | Reason |
+|------|---------|--------|
+| 8080 | App container | Nginx proxies to it internally |
+| 8090 | Keycloak container | Nginx proxies to it internally |
+| 3306 | MySQL | Internal Docker network only |
+
+---
+
+## Troubleshooting
+
+### Check the setup log
+
+```bash
+sudo tail -200 /var/log/rtcloud-setup.log
+```
+
+### Check the SSL log
+
+```bash
+sudo tail -200 /var/log/rtcloud-ssl.log
+```
+
+### View container status
+
+```bash
+docker compose -f /opt/rtcloud/docker-compose.production.yml ps
+```

--- a/pages/deployment/cloud-providers/gcp-compute-engine.mdx
+++ b/pages/deployment/cloud-providers/gcp-compute-engine.mdx
@@ -1,0 +1,168 @@
+---
+title: "Google Cloud Platform (GCP)"
+description: "Deploy rtCloud on a Google Cloud Compute Engine VM using an automated startup script. No configuration needed — just create the server and follow the post-deployment steps."
+---
+
+## Before you start
+
+- You need a [Google account](https://accounts.google.com)
+- New GCP accounts get **$300 in free credits** valid for 90 days — no charge until you manually upgrade
+- A credit card is required for verification only
+
+---
+
+## Step 1 — Create a GCP account
+
+Go to **[console.cloud.google.com/freetrial](https://console.cloud.google.com/freetrial)**
+
+1. Sign in with your Google account
+2. Enter your credit card details (verification only — you will not be charged)
+3. Click **Start free** — your $300 credit activates immediately
+
+---
+
+## Step 2 — Create a project
+
+1. Go to **[console.cloud.google.com](https://console.cloud.google.com)**
+2. Click the project dropdown at the top → **New Project**
+3. Enter a name (e.g. `rtsurvey`) → **Create**
+4. Select the new project from the dropdown
+
+---
+
+## Step 3 — Enable Compute Engine API
+
+Go to **[Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com)** → click **Enable**
+
+Wait about 1 minute for GCP to provision the API.
+
+---
+
+## Step 4 — Create a VM instance
+
+1. Go to **Compute Engine** → **VM instances** → **Create Instance**
+2. Fill in the form:
+
+| Field | Recommended value |
+|-------|------------------|
+| **Name** | `rtsurvey-prod` |
+| **Region** | Closest to your users (e.g. `asia-east1` for Southeast Asia) |
+| **Machine type** | `e2-medium` (2 vCPU / 4 GB RAM) |
+| **Boot disk** | Click **Change** → Ubuntu 22.04 LTS → 20 GB → **Select** |
+| **Firewall** | ✅ Allow HTTP traffic &nbsp; ✅ Allow HTTPS traffic |
+
+3. Click **Advanced options** → **Management** → scroll to **Automation**
+4. Paste the full contents of `gcp-compute.sh` into the **Startup script** field
+5. Click **Create**
+
+> **No configuration needed.** The script uses safe defaults and starts in HTTP mode. You configure the domain and SSL from the app UI after the server is running — the same flow as Linode.
+
+**Download script:** [gcp-compute.sh](/scripts/gcp-compute.sh)
+
+### Recommended VM sizes
+
+| Machine type | RAM | ~$/month | $300 trial lasts |
+|--------------|-----|----------|-----------------|
+| `e2-medium` | 4 GB | ~$27 | ~11 months |
+| `e2-standard-2` | 8 GB | ~$49 | ~6 months |
+
+---
+
+## Step 5 — Open port 3838 (Shiny)
+
+GCP's **Allow HTTP/HTTPS** checkboxes only open ports 80 and 443. Port 3838 (Shiny analytics) requires a separate rule.
+
+1. Go to **VPC network** → **Firewall** → **Create firewall rule**
+2. Fill in the rule:
+
+| Field | Value |
+|-------|-------|
+| **Name** | `allow-shiny-3838` |
+| **Direction** | Ingress |
+| **Action** | Allow |
+| **Targets** | All instances in the network |
+| **Source IPv4 ranges** | `0.0.0.0/0` |
+| **Protocols and ports** | TCP `3838` |
+
+3. Click **Create**
+
+---
+
+## Step 6 — Wait for setup to complete
+
+The script runs automatically on first boot. It installs Docker, pulls the rtCloud image, initialises the database, and starts all services. This takes **5–10 minutes**.
+
+**No console access needed.** Open your browser and go to `http://<vm-external-ip>`. You will see a loading page while the app finishes starting up. It refreshes automatically every 5 seconds and loads the app once ready.
+
+> The VM external IP is shown in the **Compute Engine → VM instances** list.
+
+To watch the log directly:
+
+```bash
+ssh <user>@<vm-external-ip>
+sudo tail -f /var/log/rtcloud-setup.log
+```
+
+---
+
+## Step 7 — Set up SSL
+
+Once the app is running, follow the **[Set Up SSL guide →](../ssl-setup)** to configure HTTPS. The free **rtsurvey.com subdomain** is the fastest option — no DNS setup needed.
+
+---
+
+## Step 8 — Change the default password
+
+All passwords default to `admin`. Change them immediately after your first login:
+
+- **App admin password** — account settings inside the app
+- **Keycloak admin** — accessible at `https://your-domain.com/auth/admin` (login: `admin` / `admin`)
+
+---
+
+## Firewall rules (GCP VPC)
+
+The startup script configures `ufw` inside the VM. You also need these VPC-level firewall rules in GCP:
+
+### Inbound
+
+| Rule name | Protocol | Port | Notes |
+|-----------|----------|------|-------|
+| `default-allow-ssh` | TCP | 22 | SSH access (GCP default) |
+| `default-allow-http` | TCP | 80 | Nginx HTTP + ACME challenge |
+| `default-allow-https` | TCP | 443 | Nginx HTTPS after SSL setup |
+| `allow-shiny-3838` | TCP | 3838 | Shiny Server (R analytics) |
+
+### Ports NOT needed externally
+
+| Port | Service | Reason |
+|------|---------|--------|
+| 8080 | App container | Nginx proxies to it internally |
+| 8090 | Keycloak container | Nginx proxies to it internally |
+| 3306 | MySQL | Internal Docker network only |
+
+---
+
+## Troubleshooting
+
+### Check the setup log
+
+```bash
+sudo tail -200 /var/log/rtcloud-setup.log
+```
+
+### Check the SSL log
+
+```bash
+sudo tail -200 /var/log/rtcloud-ssl.log
+```
+
+### View container status
+
+```bash
+docker compose -f /opt/rtcloud/docker-compose.production.yml ps
+```
+
+### Reboot behavior
+
+GCP reruns the startup script on every VM reboot. The script detects an existing installation at `/opt/rtcloud/` and exits immediately — no re-provisioning occurs.

--- a/pages/deployment/cloud-providers/index.mdx
+++ b/pages/deployment/cloud-providers/index.mdx
@@ -1,0 +1,51 @@
+---
+title: "Cloud Providers"
+description: "Deploy rtCloud on a cloud VM in minutes using automated startup scripts for DigitalOcean, Linode, GCP, and AWS."
+---
+
+import FeatureCard from '../../../components/FeatureCard';
+
+# Cloud Providers
+
+Each provider page includes a ready-to-use startup script that installs Docker, pulls the rtCloud image, and configures all services on first boot.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '1rem', marginTop: '2rem', marginBottom: '2rem' }}>
+
+<FeatureCard
+  title="DigitalOcean"
+  href="/deployment/cloud-providers/digitalocean"
+  iconColor="#0080ff"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm0 16.5v-3.17c2.376-.24 4.25-2.235 4.25-4.67 0-2.6-2.1-4.71-4.71-4.71-2.61 0-4.71 2.11-4.71 4.71h3.17c0-.85.69-1.54 1.54-1.54.85 0 1.54.69 1.54 1.54 0 .85-.69 1.54-1.54 1.54H9.33v3.17H7.17V14.5H5v-2.17h2.17C7.17 9.1 9.39 6.87 12 6.87c2.6 0 4.71 2.1 4.71 4.71 0 2.6-2.11 4.71-4.71 4.71V18.5z"/></svg>}
+>
+  Droplet with User Data script. Edit config vars, paste the script, and boot.
+</FeatureCard>
+
+<FeatureCard
+  title="Linode (Akamai)"
+  href="/deployment/cloud-providers/linode"
+  iconColor="#02b159"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>}
+>
+  One-click StackScript. Fill in Linode's form and the script runs automatically.
+</FeatureCard>
+
+<FeatureCard
+  title="GCP Compute Engine"
+  href="/deployment/cloud-providers/gcp-compute-engine"
+  iconColor="#4285f4"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>}
+>
+  VM with Startup script. Paste the script in Console and add a firewall rule for port 3838.
+</FeatureCard>
+
+
+<FeatureCard
+  title="AWS EC2"
+  href="/deployment/cloud-providers/aws-ec2"
+  iconColor="#ff9900"
+  icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M13.527 0C6.055 0 0 6.055 0 13.527c0 5.985 3.89 11.07 9.289 12.87l.52-.52c-4.83-1.62-8.32-6.17-8.32-11.35 0-6.69 5.44-12.13 12.13-12.13 6.69 0 12.13 5.44 12.13 12.13 0 5.18-3.49 9.73-8.32 11.35l.52.52c5.4-1.8 9.29-6.885 9.29-12.87C27.054 6.055 21 0 13.527 0z"/></svg>}
+>
+  EC2 with User Data script. Paste the script at launch and configure SSL from the app UI.
+</FeatureCard>
+
+</div>


### PR DESCRIPTION
## Summary

- Add `aws-ec2.mdx` — full AWS EC2 deployment guide matching Linode page style
- Add AWS EC2 card to cloud providers index page
- Update `_meta.json` to include AWS EC2 in sidebar navigation
- Update index page description to mention AWS

## What's covered

- EC2 launch steps (AMI, instance type, user data)
- Security group rules (ports 22, 80, 443, 3838)
- Waiting page / auto-reload note
- SSL via app UI post-boot (matches Linode flow)
- Troubleshooting section

## Test plan

- [ ] Verify page renders on docs.rtsurvey.com
- [ ] Verify AWS EC2 card appears on cloud providers index
- [ ] Verify sidebar navigation includes AWS EC2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS EC2 and GCP Compute Engine deployment guides, and updates the Cloud Providers index and sidebar. Both guides use paste-and-launch scripts, start in HTTP, and direct SSL setup from the app after boot.

- **New Features**
  - Added `aws-ec2.mdx`: EC2 launch steps, security group rules (22, 80, 443, 3838), waiting page with auto-reload, SSL via app UI, troubleshooting.
  - Added `gcp-compute-engine.mdx`: Linode-style guide with $300 free trial steps, startup script, VPC firewall for 3838, reboot guard, troubleshooting.
  - Added `cloud-providers/index.mdx` with provider cards (including AWS); updated `_meta.json` to include GCP and AWS and hide index; updated index description to mention AWS.

<sup>Written for commit 48973d34f0fe9569d60393bb24eca281b0175e3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

